### PR TITLE
Fix endpoint response

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,54 +1,54 @@
 {
-  "name": "@7span/directus-extension-custom-query-panel",
-  "version": "1.1.6",
-  "scripts": {
-    "build": "directus-extension build",
-    "dev": "directus-extension build -w --no-minify",
-    "link": "directus-extension link",
-    "add": "directus-extension add",
-    "prepublishOnly": "npm run build"
-  },
-  "directus:extension": {
-    "host": "^9.22.4",
-    "type": "bundle",
-    "path": {
-      "app": "dist/app.js",
-      "api": "dist/api.js"
+    "name": "@7span/directus-extension-custom-query-panel",
+    "version": "1.1.7",
+    "scripts": {
+        "build": "directus-extension build",
+        "dev": "directus-extension build -w --no-minify",
+        "link": "directus-extension link",
+        "add": "directus-extension add",
+        "prepublishOnly": "npm run build"
     },
-    "entries": [
-      {
-        "type": "panel",
-        "name": "custom-query-panel",
-        "source": "src/custom-query-panel/index.js"
-      },
-      {
-        "type": "endpoint",
-        "name": "custom-query",
-        "source": "src/custom-query/index.js"
-      }
+    "directus:extension": {
+        "host": "^9.22.4",
+        "type": "bundle",
+        "path": {
+            "app": "dist/app.js",
+            "api": "dist/api.js"
+        },
+        "entries": [
+            {
+                "type": "panel",
+                "name": "custom-query-panel",
+                "source": "src/custom-query-panel/index.js"
+            },
+            {
+                "type": "endpoint",
+                "name": "custom-query",
+                "source": "src/custom-query/index.js"
+            }
+        ]
+    },
+    "devDependencies": {
+        "@directus/extensions-sdk": "9.22.4",
+        "vue": "^3.2.47"
+    },
+    "author": {
+        "name": "7span",
+        "email": "yo@7span.com"
+    },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/7span/directus-extension-custom-query-panel.git"
+    },
+    "homepage": "https://github.com/7span/directus-extension-custom-query-panel#Readme",
+    "publishConfig": {
+        "access": "public"
+    },
+    "dependencies": {
+        "dotenv": "^16.3.1",
+        "paraphrase": "^3.1.1"
+    },
+    "files": [
+        "dist"
     ]
-  },
-  "devDependencies": {
-    "@directus/extensions-sdk": "9.22.4",
-    "vue": "^3.2.47"
-  },
-  "author": {
-    "name": "7span",
-    "email": "yo@7span.com"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/7span/directus-extension-custom-query-panel.git"
-  },
-  "homepage": "https://github.com/7span/directus-extension-custom-query-panel#Readme",
-  "publishConfig": {
-    "access": "public"
-  },
-  "dependencies": {
-    "dotenv": "^16.3.1",
-    "paraphrase": "^3.1.1"
-  },
-  "files": [
-    "dist"
-  ]
 }

--- a/src/custom-query-panel/panel.vue
+++ b/src/custom-query-panel/panel.vue
@@ -71,9 +71,10 @@ export default {
             this.api(`custom-query-panel/execute`, {
                 params: {
                     query_id: this.query_id,
-                    variables: this.variables.length
-                        ? this.variables
-                        : undefined,
+                    variables:
+                        this.variables && this.variables.length
+                            ? this.variables
+                            : undefined,
                 },
             })
                 .then((res) => {

--- a/src/custom-query/index.js
+++ b/src/custom-query/index.js
@@ -33,7 +33,7 @@ export default {
         const RAW_QUERY = phrase(`${customQueryData.query}`, preparedVariables);
         logger.debug(`Raw query: ${RAW_QUERY}`);
         const executedQueryData = await database.raw(RAW_QUERY);
-        const fetchedQueryData = executedQueryData[0];
+        const fetchedQueryData = executedQueryData.rows;
 
         logger.debug("Custom Query Executed");
         return res.status(200).json({ data: fetchedQueryData });


### PR DESCRIPTION
This PR corrects the data structure in the endpoint response. It changes the response to return `executedQueryData.rows` instead of `executedQueryData[0]`, ensuring the full query result set is properly retrieved.